### PR TITLE
Fix missing Continues from area scripts.

### DIFF
--- a/gorgon/scripts/h_bandia.baf
+++ b/gorgon/scripts/h_bandia.baf
@@ -6,6 +6,7 @@ THEN
                  DayNight(MIDNIGHT)
                  CreateCreature("h_nagatc",[1973.2895],S)
                  SetGlobal("h_SpawnNagate","GLOBAL",2)
+                 Continue()
 END
 
 IF
@@ -14,4 +15,5 @@ IF
 THEN
         RESPONSE #100
                  PlaySong(0)
+                 Continue()
 END

--- a/gorgon/scripts/h_berega.baf
+++ b/gorgon/scripts/h_berega.baf
@@ -27,7 +27,8 @@ THEN
                   CreateCreature("h_sthiec",[1417.3265],S)
                   CreateCreature("h_sthiec",[1487.3380],S)
                   CreateCreature("h_thiefc",[1333.3351],S)
-         SetGlobal("h_ShadowWar","GLOBAL",2)
+                  SetGlobal("h_ShadowWar","GLOBAL",2)
+                  Continue()
 END
 
 IF
@@ -37,6 +38,7 @@ THEN
          RESPONSE #100
                   SetGlobal("h_RandomEncounterForced","GLOBAL",1)
                   ForceRandomEncounterEntry("h_flamea","h_flamee")
+                  Continue()
 END
 
 IF
@@ -48,6 +50,7 @@ THEN
          RESPONSE #100
                   SetGlobal("h_RandomEncounterForced","GLOBAL",2)
                   ForceRandomEncounterEntry("h_flamea","h_flamee")
+                  Continue()
 END
 
 IF
@@ -58,6 +61,7 @@ THEN
          RESPONSE #100
                   CreateCreature("h_zhontc",[4217.2378],N)
                   SetGlobal("h_SpawnZhontac","GLOBAL",1)
+                  Continue()
 END
 
 IF
@@ -67,6 +71,7 @@ THEN
          RESPONSE #100
                   CreateCreature("h_magnuc",[2718.3107],W)
                   SetGlobal("h_SpawnMagnus","GLOBAL",1)
+                  Continue()
 END
 
 IF
@@ -75,6 +80,7 @@ THEN
          RESPONSE #100
                   CreateCreature("h_yumilc",[1701.2846],N)
                   SetGlobal("h_SpawnYumil","GLOBAL",1)
+                  Continue()
 END
 
 IF
@@ -83,4 +89,5 @@ IF
 THEN
         RESPONSE #100
                  PlaySong(0)
+                 Continue()
 END

--- a/gorgon/scripts/h_carnia.baf
+++ b/gorgon/scripts/h_carnia.baf
@@ -6,6 +6,7 @@ THEN
                   CreateCreature("h_roguec",[1077.2260],S)
                   CreateCreature("h_roguec",[1142.2249],S)
                   SetGlobal("h_GuildThieves","GLOBAL",3)
+                  Continue()
 END
 
 IF
@@ -20,6 +21,7 @@ THEN
                   CreateCreature("h_thiefc",[4550.2206],E)
                   CreateCreature("h_thiefc",[4550.2296],E)
                   SetGlobal("h_ShadowWar","GLOBAL",6)
+                  Continue()
 END
 
 IF
@@ -27,4 +29,5 @@ IF
 THEN
          RESPONSE #100
                   PlaySong(0)
+                  Continue()
 END

--- a/gorgon/scripts/h_fai3fa.baf
+++ b/gorgon/scripts/h_fai3fa.baf
@@ -5,4 +5,5 @@ THEN
         RESPONSE #100
                  CreateCreature("h_carthc",[784.228],E)
                  SetGlobal("h_SpawnCarth","GLOBAL",1)
+                 Continue()
 END

--- a/gorgon/scripts/h_flamea.baf
+++ b/gorgon/scripts/h_flamea.baf
@@ -6,6 +6,7 @@ THEN
                   CreateCreature("h_flamec",[440.661],N)
                   CreateCreature("h_flamec",[524.658],N)
                   SetGlobal("h_FlamingFist","GLOBAL",2)
+                  Continue()
 
 END
 

--- a/gorgon/scripts/h_gerara.baf
+++ b/gorgon/scripts/h_gerara.baf
@@ -5,6 +5,7 @@ THEN
         RESPONSE #100
                  CreateCreature("h_bald2c",[617.365],N)
                  SetGlobal("h_SpawnBaldwin","GLOBAL",2)
+                 Continue()
 END
 
 IF

--- a/gorgon/scripts/h_gibbea.baf
+++ b/gorgon/scripts/h_gibbea.baf
@@ -4,4 +4,5 @@ THEN
         RESPONSE #100
                  CreateCreature("h_denebc",[4210.584],S)
                  SetGlobal("h_SpawnDeneb","GLOBAL",2)
+                 Continue()
 END

--- a/gorgon/scripts/h_guilda.baf
+++ b/gorgon/scripts/h_guilda.baf
@@ -26,6 +26,7 @@ THEN
 
 
                   SetGlobal("h_GuildSpawn","GLOBAL",1)
+                  Continue()
 END
 
 IF
@@ -36,6 +37,7 @@ THEN
                   CreateCreature("h_roguec",[1006.1057],SW)
                   CreateCreature("h_roguec",[1059.1101],SW)
                   SetGlobal("h_GuildThieves","GLOBAL",1)
+                  Continue()
 END
 
 IF
@@ -45,6 +47,7 @@ THEN
                   CreateCreature("h_roguec",[1006.1057],SW)
                   CreateCreature("h_roguec",[1059.1101],SW)
                   SetGlobal("h_GuildThieves","GLOBAL",6)
+                  Contibue()
 END
 
 IF
@@ -53,6 +56,7 @@ THEN
          RESPONSE #100
                   CreateCreature("h_ariosc",[823.1454],N)
                   SetGlobal("h_SpawnAriosh","GLOBAL",2)
+                  Continue()
 END
 
 IF
@@ -63,6 +67,7 @@ THEN
                   CreateCreature("h_roguec",[1006.1057],SW)
                   CreateCreature("h_roguec",[1059.1101],SW)
                   SetGlobal("h_SpawnAriosh","GLOBAL",5)
+                  Continue()
 END
 
 IF
@@ -70,6 +75,7 @@ IF
 THEN
          RESPONSE #100
                   SoundActivate("GuildMusic",TRUE)
+                  Continue()
 END
 
 IF
@@ -77,6 +83,7 @@ IF
 THEN
          RESPONSE #100
                   SoundActivate("GuildMusic",TRUE)
+                  Continue()
 END
 
 IF
@@ -84,6 +91,7 @@ IF
 THEN
          RESPONSE #100
                   SoundActivate("GuildMusic",FALSE)
+                  Continue()
 END
 
 IF
@@ -91,6 +99,7 @@ IF
 THEN
          RESPONSE #100
                   SoundActivate("GuildMusic",TRUE)
+                  Continue()
 END
 
 IF

--- a/gorgon/scripts/h_highha.baf
+++ b/gorgon/scripts/h_highha.baf
@@ -6,5 +6,6 @@ THEN
                   CreateCreature("h_tuztcc",[290.2527],S)
                   CreateCreature("h_bountc",[215.2496],S)
                   CreateCreature("h_bountc",[316.2461],S)
-         SetGlobal("h_SpawnEuropea","GLOBAL",2)
+                  SetGlobal("h_SpawnEuropea","GLOBAL",2)
+                  Continue()
 END

--- a/gorgon/scripts/h_larswa.baf
+++ b/gorgon/scripts/h_larswa.baf
@@ -5,4 +5,5 @@ THEN
         RESPONSE #100
                  CreateCreature("h_katrec",[2185.776],S)
                  SetGlobal("h_SpawnKatreda","GLOBAL",1)
+                 Continue()
 END

--- a/gorgon/scripts/h_red2fa.baf
+++ b/gorgon/scripts/h_red2fa.baf
@@ -5,4 +5,5 @@ THEN
         RESPONSE #100
                  CreateCreature("h_aishac",[163.551],E)
                  SetGlobal("h_SpawnAisha","GLOBAL",1)
+                 Continue()
 END

--- a/gorgon/scripts/h_tbw2fa.baf
+++ b/gorgon/scripts/h_tbw2fa.baf
@@ -5,4 +5,5 @@ THEN
         RESPONSE #100
                  CreateCreature("h_amriuc",[377.350],E)
                  SetGlobal("h_SpawnAmrius","GLOBAL",1)
+                 Continue()
 END

--- a/gorgon/scripts/h_templa.baf
+++ b/gorgon/scripts/h_templa.baf
@@ -5,4 +5,5 @@ THEN
         RESPONSE #100
                  CreateCreature("h_vapulc",[604.204],S)
                  SetGlobal("h_SpawnVapula","GLOBAL",1)
+                 Continue()
 END


### PR DESCRIPTION
Without a Continue(), the script parser stops parsing everything after
it entered into a block. Because you're using EXTEND_TOP, your scripts
will delay other mods installed earlier/using EXTEND_BOTTOM and/or the
basegame area script actions by 6 seconds to trigger because these
scripts are only iterated every turn. Continue() is needed to ensure
everything is iterated during the first turn.

I presume this will actually break a fair amount of areas because the
PlaySongs also get immedaitely iterated - although I presume the
PlaySongs are actually leftover debug actions which should be deleted.